### PR TITLE
fix: set offline_access scope for /authorize call

### DIFF
--- a/src/api/callback.js
+++ b/src/api/callback.js
@@ -23,18 +23,18 @@ async function auth0FetchOAuthToken(code, state, redirectUrl, organization) {
     `https://${process.env.VITE_AUTH0_DOMAIN}/oauth/token`
   )
 
-  const formData = new URLSearchParams()
   const scopes = ['openid', 'profile', 'email']
+  if (process.env.VITE_AUTH0_OFFLINE_ACCESS === 'true') {
+    scopes.push('offline_access')
+  }
+
+  const formData = new URLSearchParams()
   formData.append('grant_type', 'authorization_code')
   formData.append('client_id', process.env.VITE_AUTH0_CLIENT_ID)
   formData.append('client_secret', process.env.AUTH0_CLIENT_SECRET)
   formData.append('code', code)
   formData.append('state', state)
   formData.append('redirect_uri', redirectUrl)
-
-  if (process.env.VITE_AUTH0_OFFLINE_ACCESS === 'true') {
-    scopes.push('offline_access')
-  }
   formData.append('scope', scopes.join(' '))
 
   if (organization) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -24,12 +24,18 @@ export function Auth0(props) {
   const [userId, setUserId] = createSignal()
   const [organization, setOrganization] = createSignal()
 
+  const scopes = ['openid', 'profile', 'email']
+  if (process.env.VITE_AUTH0_OFFLINE_ACCESS === 'true') {
+    scopes.push('offline_access')
+  }
+
   const webAuthnConfig = {
     _sendTelemetry: false,
     domain: auth0config.domain,
     clientID: auth0config.clientId,
     audience: auth0config.audience,
     redirectUri: auth0config.redirectUri,
+    scopes: scopes.join(' '),
     responseType: 'code'
   }
 


### PR DESCRIPTION
Also set the `offline_access` scope for the `/authorize` request to allow fetching a refresh token later via `/oauth/token`

Closes #4 