### PR TITLE
feat: add getSession utility in order to access a session on the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
       "require": "./src/index.jsx",
       "solid": "./src/index.jsx"
     },
-    "./api/*": "./src/api/*"
+    "./api/*": "./src/api/*",
+    "./server": "./src/server/index.js"
   },
   "main": "src/index.js",
   "types": "./src/index.d.ts",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,13 @@ declare module '@zentered/auth0-solid-start/api/logout' {
   export default function (req: APIEvent['request']): void
 }
 
+declare module '@zentered/auth0-solid-start/server' {
+  import type { ServerFunctionEvent } from 'solid-start/server'
+  import type { Session } from 'solid-start/session/sessions'
+
+  export function getSession(event: ServerFunctionEvent): Promise<Session>
+}
+
 declare module '@zentered/auth0-solid-start' {
   import { Accessor, JSX } from 'solid-js'
   import type { WebAuth } from 'auth0-js'

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,0 +1,3 @@
+import { storage } from '../session'
+export const getSession = async (event) =>
+  storage.getSession(event.request.headers.get('Cookie'))


### PR DESCRIPTION
Currently, the library doesn't provide any utilities in order to access a session on the server.